### PR TITLE
[design/#64]세팅 단계를 보여주는 화살표 구현

### DIFF
--- a/src/components/BackendStepper.jsx
+++ b/src/components/BackendStepper.jsx
@@ -1,5 +1,20 @@
-const BackendStepper = () => {
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import blueSnake from '../assets/image/blueSnake.svg'; // 이미지 경로를 정확히 입력해주세요.
 
+const BackendStepper = () => {
+  const location = useLocation();
+
+  const getTextForPath = (path) => {
+    switch (path) {
+      case '/backframework':
+        return 'Framework';
+      case '/backdatabase':
+        return 'Database';
+      default:
+        return '';
+    }
+  };
 
   return (
     <div className="flex h-10 w-full items-center justify-between px-4">
@@ -16,6 +31,7 @@ const BackendStepper = () => {
       <div className="relative mx-4 flex flex-1 items-center">
         {/* 점선 */}
         <div className="h-1 w-full border-t-2 border-dashed border-blue-main"></div>
+
         {/* 중간 점 */}
         <div
           className="absolute top-1/2 -translate-y-1/2 transform"
@@ -24,6 +40,7 @@ const BackendStepper = () => {
           <div className="h-4 w-4 rounded-full bg-blue-main"></div>
         </div>
 
+        {/* 첫 번째 단계 */}
         <div
           className="absolute top-1/2 -translate-y-1/2 transform"
           style={{ left: '30%' }}
@@ -32,7 +49,26 @@ const BackendStepper = () => {
           <div className="absolute -inset-1 rounded-full bg-blue-400 opacity-50"></div>
           {/* 중간 점 */}
           <div className="h-4 w-4 rounded-full bg-blue-main"></div>
+          {/* 그림 */}
+          {location.pathname === '/backframework' && (
+            <img
+              src={blueSnake}
+              alt="blueSnake"
+              className="absolute -top-5 left-1/2 h-8 w-8 -translate-x-1/2 transform"
+            />
+          )}
+          {/* 텍스트 */}
+          {location.pathname === '/backframework' && (
+            <span
+              className="absolute top-full mt-2 text-[1rem] text-white"
+              style={{ left: '50%', transform: 'translateX(-50%)' }}
+            >
+              {getTextForPath('/backframework')}
+            </span>
+          )}
         </div>
+
+        {/* 두 번째 단계 */}
         <div
           className="absolute top-1/2 -translate-y-1/2 transform"
           style={{ left: '70%' }}
@@ -41,7 +77,25 @@ const BackendStepper = () => {
           <div className="absolute -inset-1 rounded-full bg-blue-400 opacity-50"></div>
           {/* 중간 점 */}
           <div className="h-4 w-4 rounded-full bg-blue-main"></div>
+          {/* 그림 */}
+          {location.pathname === '/backdatabase' && (
+            <img
+              src={blueSnake}
+              alt="blueSnake"
+              className="absolute -top-5 left-1/2 h-8 w-8 -translate-x-1/2 transform"
+            />
+          )}
+          {/* 텍스트 */}
+          {location.pathname === '/backdatabase' && (
+            <span
+              className="absolute top-full mt-2 text-[1rem] text-white"
+              style={{ left: '50%', transform: 'translateX(-50%)' }}
+            >
+              {getTextForPath('/backdatabase')}
+            </span>
+          )}
         </div>
+
         {/* 화살표 */}
         <div
           className="absolute top-1/2 -translate-y-1/2 transform"
@@ -59,9 +113,4 @@ const BackendStepper = () => {
   );
 };
 
-
-
-
 export default BackendStepper;
-
-

--- a/src/components/FrontendStepper.jsx
+++ b/src/components/FrontendStepper.jsx
@@ -1,4 +1,25 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import greenSnake from '../assets/image/greenSnake.svg';
+
 const FrontendStepper = () => {
+  const location = useLocation();
+
+  const getTextForPath = (path) => {
+    switch (path) {
+      case '/frontpackage':
+        return 'Package';
+      case '/frontbuild':
+        return 'Build';
+      case '/frontframework':
+        return 'Framework';
+      case '/frontlanguage':
+        return 'Language';
+      default:
+        return '';
+    }
+  };
+
   return (
     <div className="flex h-10 w-full items-center justify-between px-4">
       {/* Start */}
@@ -32,6 +53,23 @@ const FrontendStepper = () => {
           <div className="absolute -inset-1 rounded-full bg-green-main opacity-50"></div>
           {/* 중간 점 */}
           <div className="h-4 w-4 rounded-full bg-green-main"></div>
+          {/* 그림 */}
+          {location.pathname === '/frontpackage' && (
+            <img
+              src={greenSnake}
+              alt="greenSnake"
+              className="absolute -top-5 left-1/2 h-8 w-8 -translate-x-1/2 transform"
+            />
+          )}
+          {/* 텍스트 */}
+          {location.pathname === '/frontpackage' && (
+            <span
+              className="absolute top-full mt-2 text-[1rem] text-white"
+              style={{ left: '50%', transform: 'translateX(-50%)' }}
+            >
+              {getTextForPath('/frontpackage')}
+            </span>
+          )}
         </div>
 
         {/* 두 번째 단계*/}
@@ -41,6 +79,23 @@ const FrontendStepper = () => {
         >
           <div className="absolute -inset-1 rounded-full bg-green-main opacity-50"></div>
           <div className="h-4 w-4 rounded-full bg-green-main"></div>
+          {/* 그림 */}
+          {location.pathname === '/frontbuild' && (
+            <img
+              src={greenSnake}
+              alt="greenSnake"
+              className="absolute -top-5 left-1/2 h-8 w-8 -translate-x-1/2 transform"
+            />
+          )}
+          {/* 텍스트 */}
+          {location.pathname === '/frontbuild' && (
+            <span
+              className="absolute top-full mt-2 text-[1rem] text-white"
+              style={{ left: '50%', transform: 'translateX(-50%)' }}
+            >
+              {getTextForPath('/frontbuild')}
+            </span>
+          )}
         </div>
 
         {/* 세 번째 단계 */}
@@ -50,6 +105,23 @@ const FrontendStepper = () => {
         >
           <div className="absolute -inset-1 rounded-full bg-green-main opacity-50"></div>
           <div className="h-4 w-4 rounded-full bg-green-main"></div>
+          {/* 그림 */}
+          {location.pathname === '/frontframework' && (
+            <img
+              src={greenSnake}
+              alt="greenSnake"
+              className="absolute -top-5 left-1/2 h-8 w-8 -translate-x-1/2 transform"
+            />
+          )}
+          {/* 텍스트 */}
+          {location.pathname === '/frontframework' && (
+            <span
+              className="absolute top-full mt-2 text-[1rem] text-white"
+              style={{ left: '50%', transform: 'translateX(-50%)' }}
+            >
+              {getTextForPath('/frontframework')}
+            </span>
+          )}
         </div>
 
         {/* 네 번째 단계 */}
@@ -59,6 +131,23 @@ const FrontendStepper = () => {
         >
           <div className="absolute -inset-1 rounded-full bg-green-main opacity-50"></div>
           <div className="h-4 w-4 rounded-full bg-green-main"></div>
+          {/* 그림 */}
+          {location.pathname === '/frontlanguage' && (
+            <img
+              src={greenSnake}
+              alt="greenSnake"
+              className="absolute -top-5 left-1/2 h-8 w-8 -translate-x-1/2 transform"
+            />
+          )}
+          {/* 텍스트 */}
+          {location.pathname === '/frontlanguage' && (
+            <span
+              className="absolute top-full mt-2 text-[1rem] text-white"
+              style={{ left: '50%', transform: 'translateX(-50%)' }}
+            >
+              {getTextForPath('/frontlanguage')}
+            </span>
+          )}
         </div>
 
         {/* 화살표 */}

--- a/src/pages/BackFramework.jsx
+++ b/src/pages/BackFramework.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import ChooseBox from '../components/ChooseBox';
@@ -11,6 +11,7 @@ import springboot from '../assets/image/springboot.svg';
 const BackFramework = () => {
   const navigate = useNavigate();
   const [selectedBox, setSelectedBox] = useState(null); // selectedBox 상태 추가
+
   const GoBackDatabase = () => {
     navigate('/backdatabase');
   };
@@ -26,7 +27,7 @@ const BackFramework = () => {
 
         {/* BackSettingStep을 컨테이너 내부에 배치 */}
         <div className="mb-auto ml-auto mt-auto flex w-3/4 items-center justify-center">
-          <BackendStepper />
+          <BackendStepper PcurrentPage={0} />
         </div>
 
         {/* ChooseBox를 일렬로 배열 */}

--- a/src/pages/FrontPackage.jsx
+++ b/src/pages/FrontPackage.jsx
@@ -30,7 +30,7 @@ const FrontPackage = () => {
 
         {/* FrontSettingStep을 컨테이너 내부에 배치 */}
         <div className="mb-auto ml-auto mt-auto flex w-3/4 items-center justify-center">
-          <FrontendStepper />
+          <FrontendStepper currentPage={0} />
         </div>
 
         {/* ChooseBox를 일렬로 배열 */}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#64 

## 📝작업 내용
백엔드, 프론트엔드 세팅 페이지에서 단계를 보여주는 화살표 완성했습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)
<img width="1347" alt="스크린샷 2025-01-16 오전 3 01 07" src="https://github.com/user-attachments/assets/6063c5a0-36b7-4a9d-aadc-17b2fb147749" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
